### PR TITLE
Publish the image on ghcr.io/freedomofpress/dangerzone/v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       registry: ghcr.io/${{ github.repository_owner }}
       registry_user: ${{ github.actor }}
-      image_name: dangerzone-alpha/v1
+      image_name: dangerzone/v1
       reproduce: true
       # Pass sign=false here as signing is a manual process for the nightly images.
       sign: false

--- a/build-image.py
+++ b/build-image.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 BUILD_CONTEXT = "src"
-IMAGE_NAME = "ghcr.io/freedomofpress/dangerzone-alpha/v1"
+IMAGE_NAME = "ghcr.io/freedomofpress/dangerzone/v1"
 CONTAINER_RUNTIME = "podman"
 ANNOTATION_DATE = "rocks.dangerzone.debian_archive_date={date}"
 


### PR DESCRIPTION
Previously, we were using freedomofpress/dangerzone-alpha/v1 for temporary testing.