### PR TITLE
Remove container extras dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
           uv run image build -d "$DATE"
 
       - name: Load local image for tests
-        run: |
-          podman load -i container.tar
-          cp image-id.txt tests/share/image-id.txt
+        run: podman load -i container.tar
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,19 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+      - name: Upload pixel diff artifacts
+        if: failure() && hashFiles('tests/_diff_artifacts/diff.html') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pixel-diff
+          path: tests/_diff_artifacts/
+
+      - name: Annotate run with diff link
+        if: failure() && hashFiles('tests/_diff_artifacts/diff.html') != ''
+        run: |
+          {
+            echo "### Reference version mismatch";
+            echo "";
+            echo "The test-produced and reference versions differ. Browse PDFs side by side by using the `pixel-diff` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ container.tar
 .python-version
 *.pyc
 helpers/
+tests/_diff_artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN \
   : "Install the necessary gVisor and Dangerzone dependencies" && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
+      -o Dpkg::Options::="--path-exclude=/usr/share/doc/*" \
+      -o Dpkg::Options::="--path-exclude=/usr/share/man/*" \
       python3 python3-fitz libreoffice-nogui libreoffice-java-common \
       python3-magic default-jre-headless fonts-noto-cjk fonts-dejavu \
       runsc unzip && \
@@ -42,6 +44,33 @@ RUN \
   dpkg-deb --extract libreoffice-h2orestart_*.deb /tmp/h2orestart && \
   mv /tmp/h2orestart/usr/lib/libreoffice/share/extensions/h2orestart /opt/libreoffice_ext/ && \
   rm -rf /tmp/h2orestart libreoffice-h2orestart_*.deb && \
+  : "Reproducibility utils: strip_path is a way to detect when files to be removed are missing" && \
+  MULTIARCH_DIR=$(echo /usr/lib/*-linux-gnu) && \
+  test -d "${MULTIARCH_DIR}" || { echo "strip: could not locate multiarch lib dir" >&2; exit 1; } && \
+  strip_path() { for p in "$@"; do test -e "$p" || { echo "strip: missing $p" >&2; exit 1; }; rm -rf "$p"; done; } && \
+  : "gVisor: drop some binaries we don't use" && \
+  strip_path \
+      /usr/bin/runsc-metric-server \
+      /usr/bin/containerd-shim-runsc-v1 && \
+  : "Libreoffice: remove import libraries used by libwpftdrawlo.so, whose formats we do not support" && \
+  for lib in libcdr libfreehand libmspub libpagemaker libqxp libvisio libzmf; do \
+    matches=$(ls ${MULTIARCH_DIR}/${lib}-*.so* 2>/dev/null) && \
+    test -n "${matches}" || { echo "strip: no files matched ${lib}-*" >&2; exit 1; } && \
+    rm -f ${MULTIARCH_DIR}/${lib}-*.so*; \
+  done && \
+  : "Libreoffice: drop some GUI artifacts that are never loaded and only keep the default theme (colibre)" && \
+  strip_path \
+      /usr/lib/libreoffice/share/gallery \
+      /usr/lib/libreoffice/share/template \
+      /usr/lib/libreoffice/share/wizards \
+      /usr/lib/libreoffice/share/basic \
+      /usr/lib/libreoffice/share/autotext \
+      /usr/lib/libreoffice/share/autocorr \
+      /usr/share/libreoffice/share/config/images_colibre_dark.zip \
+      /usr/share/libreoffice/share/config/images_colibre_svg.zip \
+      /usr/share/libreoffice/share/config/images_colibre_dark_svg.zip && \
+  : "Drop doc and manpages, not required for this image to function" && \
+  rm -rf /usr/share/doc /usr/share/man && \
   : "Clean up for improving reproducibility (optional)" && \
   rm -rf /var/cache/fontconfig/ && \
   rm -rf /etc/ssl/certs/java/cacerts && \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -32,6 +32,8 @@ RUN \
   : "Install the necessary gVisor and Dangerzone dependencies" && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
+      -o Dpkg::Options::="--path-exclude=/usr/share/doc/*" \
+      -o Dpkg::Options::="--path-exclude=/usr/share/man/*" \
       python3 python3-fitz libreoffice-nogui libreoffice-java-common \
       python3-magic default-jre-headless fonts-noto-cjk fonts-dejavu \
       runsc unzip && \
@@ -42,6 +44,33 @@ RUN \
   dpkg-deb --extract libreoffice-h2orestart_*.deb /tmp/h2orestart && \
   mv /tmp/h2orestart/usr/lib/libreoffice/share/extensions/h2orestart /opt/libreoffice_ext/ && \
   rm -rf /tmp/h2orestart libreoffice-h2orestart_*.deb && \
+  : "Reproducibility utils: strip_path is a way to detect when files to be removed are missing" && \
+  MULTIARCH_DIR=$(echo /usr/lib/*-linux-gnu) && \
+  test -d "${MULTIARCH_DIR}" || { echo "strip: could not locate multiarch lib dir" >&2; exit 1; } && \
+  strip_path() { for p in "$@"; do test -e "$p" || { echo "strip: missing $p" >&2; exit 1; }; rm -rf "$p"; done; } && \
+  : "gVisor: drop some binaries we don't use" && \
+  strip_path \
+      /usr/bin/runsc-metric-server \
+      /usr/bin/containerd-shim-runsc-v1 && \
+  : "Libreoffice: remove import libraries used by libwpftdrawlo.so, whose formats we do not support" && \
+  for lib in libcdr libfreehand libmspub libpagemaker libqxp libvisio libzmf; do \
+    matches=$(ls ${MULTIARCH_DIR}/${lib}-*.so* 2>/dev/null) && \
+    test -n "${matches}" || { echo "strip: no files matched ${lib}-*" >&2; exit 1; } && \
+    rm -f ${MULTIARCH_DIR}/${lib}-*.so*; \
+  done && \
+  : "Libreoffice: drop some GUI artifacts that are never loaded and only keep the default theme (colibre)" && \
+  strip_path \
+      /usr/lib/libreoffice/share/gallery \
+      /usr/lib/libreoffice/share/template \
+      /usr/lib/libreoffice/share/wizards \
+      /usr/lib/libreoffice/share/basic \
+      /usr/lib/libreoffice/share/autotext \
+      /usr/lib/libreoffice/share/autocorr \
+      /usr/share/libreoffice/share/config/images_colibre_dark.zip \
+      /usr/share/libreoffice/share/config/images_colibre_svg.zip \
+      /usr/share/libreoffice/share/config/images_colibre_dark_svg.zip && \
+  : "Drop doc and manpages, not required for this image to function" && \
+  rm -rf /usr/share/doc /usr/share/man && \
   : "Clean up for improving reproducibility (optional)" && \
   rm -rf /var/cache/fontconfig/ && \
   rm -rf /etc/ssl/certs/java/cacerts && \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,31 @@ uv run pytest --local
 
 # It's also possible to run tests in parallel if you have multiple cores:
 uv run --with pytest-xdist pytest -n 6
+
+# To build the image and run the tests in one command:
+uv run pytest --build
+```
+
+#### Reference versions
+
+To make sure we generate the same documents given the same input, a reference
+version is kept in-source and used to do comparisons when running the tests. In
+case they differ, a `diff.html` page will be generated to help see the
+differences. You can open it with:
+
+```bash
+open tests/_diff_artifacts/diff.html
+```
+
+In CI, the same artifacts are uploaded as `pixel-diff` on test failure.
+Download the artifact and open `diff.html` locally.
+
+#### Regenerating reference pixel data
+
+When you are sure you want to regenerate these reference versions, do so with:
+
+```bash
+uv run pytest --update-pixel-references
 ```
 
 ## Building and reproducing the image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import subprocess
+import sys
 import zipfile
 from pathlib import Path
 from typing import List
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUILD_IMAGE_SCRIPT = REPO_ROOT / "src" / "scripts" / "image.py"
+IMAGE_ID_FILE = REPO_ROOT / "image-id.txt"
 
 # Add src directory to Python path for imports
 # src_dir = Path(__file__).parent.parent / "src"
@@ -99,16 +104,37 @@ def get_runtime_security_args() -> List[str]:
     return security_args
 
 
+def build_image() -> None:
+    """Invoke the image.py script and load the resulting tarball into podman"""
+    subprocess.run(
+        [sys.executable, str(BUILD_IMAGE_SCRIPT), "build"],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    if not IMAGE_ID_FILE.exists():
+        raise pytest.UsageError(
+            f"image.py did not produce {IMAGE_ID_FILE}. Build may have failed silently."
+        )
+    tarball = REPO_ROOT / "container.tar"
+    if not tarball.exists():
+        raise pytest.UsageError(f"image.py did not produce {tarball}.")
+    subprocess.run(
+        ["podman", "load", "-i", str(tarball)],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
 @pytest.fixture
 def container_image(request: pytest.FixtureRequest) -> str:
     """Return the container image to use for container conversion tests."""
-    image = (_DANGERZONE_SHARE_DIR / "image-id.txt").read_text().strip()
-    if not image:
-        image = request.config.getoption("--container-image")
+    image = request.config.getoption("--container-image")
+    if not image and IMAGE_ID_FILE.exists():
+        image = IMAGE_ID_FILE.read_text().strip()
     if not image:
         raise pytest.UsageError(
-            "No container image available. Provide --container-image or populate "
-            "tests/share/image-id.txt, or use --local."
+            "No container image available. Provide --container-image, run with "
+            "--build, or use --local."
         )
     return image
 
@@ -143,6 +169,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Run conversion tests locally instead of in a container",
     )
+    parser.addoption(
+        "--build",
+        action="store_true",
+        default=False,
+        help="Build the container image via build-image.py before running tests.",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -151,10 +183,17 @@ def pytest_configure(config: pytest.Config) -> None:
             "--update-pixel-references must run in a container; do not combine with "
             "--local."
         )
+    if config.getoption("--build") and config.getoption("--local"):
+        raise pytest.UsageError(
+            "--build is meaningless with --local (no container is used)."
+        )
+    if config.getoption("--build") and config.getoption("--container-image"):
+        raise pytest.UsageError("--build and --container-image are mutually exclusive.")
+    if config.getoption("--build"):
+        build_image()
     if not config.getoption("--local"):
-        image = (_DANGERZONE_SHARE_DIR / "image-id.txt").read_text().strip()
-        if not image and not config.getoption("--container-image"):
+        if not config.getoption("--container-image") and not IMAGE_ID_FILE.exists():
             raise pytest.UsageError(
-                "No container image available. Provide --container-image or populate "
-                "tests/share/image-id.txt, or use --local."
+                "No container image available. Provide --container-image, run "
+                "with --build, or use --local."
             )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -13,7 +13,86 @@ from dangerzone_insecure_converter.doc_to_pixels import DocumentToPixels
 from .conftest import TEST_DOCS_DIRECTORY, for_each_doc
 
 REFERENCE_DIR = Path(__file__).parent / "test_docs" / "reference"
+DIFF_ARTIFACTS_DIR = Path(__file__).parent / "_diff_artifacts"
 _GZIP_MAGIC = b"\x1f\x8b"
+
+
+def dump_pixel_diff(doc_name: str, actual: bytes, reference: bytes) -> Path:
+    """Write per-page PNGs for actual and reference output side-by-side.
+
+    Returns the directory containing the artifacts. Also (re)writes
+    `_diff_artifacts/diff.html`, an index of all artifact subdirectories
+    that pairs actual and reference pages for visual inspection.
+    """
+    import fitz
+
+    out_dir = DIFF_ARTIFACTS_DIR / doc_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for label, data in (("actual", actual), ("reference", reference)):
+        try:
+            pages = parse_pixel_output(data)
+        except Exception as e:
+            (out_dir / f"{label}.parse-error.txt").write_text(repr(e))
+            continue
+        for i, (width, height, rgb) in enumerate(pages, start=1):
+            pix = fitz.Pixmap(fitz.csRGB, width, height, rgb, 0)
+            pix.save(str(out_dir / f"{label}-page-{i:03d}.png"))
+
+    write_diff_index()
+    return out_dir
+
+
+def write_diff_index() -> None:
+    """Generate `_diff_artifacts/diff.html` from whatever subdirs currently exist.
+
+    Pairs each actual-page-NNN.png with its reference-page-NNN.png by filename.
+    Idempotent — safe to call after every dump.
+    """
+    docs = []
+    for sub in sorted(DIFF_ARTIFACTS_DIR.iterdir()):
+        if not sub.is_dir():
+            continue
+        page_nums = sorted(
+            int(p.stem.rsplit("-", 1)[1])
+            for p in sub.glob("actual-page-*.png")
+        )
+        if page_nums:
+            docs.append((sub.name, page_nums))
+
+    rows = []
+    for name, pages in docs:
+        rows.append(f'<h2 id="{name}">{name}</h2>')
+        for i in pages:
+            p = f"{i:03d}"
+            rows.append(
+                '<div class="pair">'
+                f'<figure><figcaption>actual page {i}</figcaption>'
+                f'<img src="{name}/actual-page-{p}.png" loading="lazy"></figure>'
+                f'<figure><figcaption>reference page {i}</figcaption>'
+                f'<img src="{name}/reference-page-{p}.png" loading="lazy"></figure>'
+                "</div>"
+            )
+
+    nav = " ".join(f'<a href="#{name}">{name}</a>' for name, _ in docs)
+    html = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>Pixel diff</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; margin: 24px; background: #1a1a1a; color: #ddd; }}
+  h1 {{ font-size: 18px; }}
+  h2 {{ font-size: 16px; margin-top: 32px; border-bottom: 1px solid #444; padding-bottom: 6px; }}
+  .pair {{ display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 24px; }}
+  .pair figure {{ margin: 0; }}
+  .pair figcaption {{ font-size: 12px; color: #888; margin-bottom: 4px; }}
+  .pair img {{ width: 100%; border: 1px solid #333; background: white; }}
+  nav a {{ color: #6cf; margin-right: 12px; }}
+</style></head><body>
+<h1>Pixel diff: actual (left) vs reference (right)</h1>
+<nav>{nav}</nav>
+{''.join(rows)}
+</body></html>
+"""
+    (DIFF_ARTIFACTS_DIR / "diff.html").write_text(html)
 
 
 class CapturingDocumentToPixels(DocumentToPixels):
@@ -135,10 +214,15 @@ async def test_convert_document(request: pytest.FixtureRequest, doc: Path) -> No
             REFERENCE_DIR.mkdir(parents=True, exist_ok=True)
             write_reference_data(reference_bin, pixel_data)
         elif reference_bin.exists():
-            assert pixel_data == read_reference_data(reference_bin), (
-                f"Pixel data does not match reference for {doc.name}. "
-                "Run with --update-pixel-references to regenerate."
-            )
+            reference_data = read_reference_data(reference_bin)
+            if pixel_data != reference_data:
+                dump_pixel_diff(doc.name, pixel_data, reference_data)
+                pytest.fail(
+                    f"Pixel data does not match reference for {doc.name}. "
+                    f"Open {DIFF_ARTIFACTS_DIR / 'diff.html'} in a browser "
+                    "to compare actual vs reference. "
+                    "Run with --update-pixel-references to regenerate."
+                )
 
     # Parse and validate pixel data structure
     pages = parse_pixel_output(pixel_data)


### PR DESCRIPTION
Fixes #17. This reduces the attack surface by removing a few binaries that we don't want.

I went with removing some parts of libreoffice that are not useful. That reduces as well our attack surface, but at the cost of cutting in the flesh.

|                    | MiB   |
  | ------------------ | ----- |
  | Previous           | 465.0 |
  | Current            | 400.8 |
  | Saved (total)      |  64.1 |
  | - of which LibreOffice      |  35.2 |
  | - other (gVisor, docs, man, …) | 28.9 |

This introduces a way to diff the pages ourselves. I've tested it locally and am not sure how the CI will behave here, so let's see.

`pytest` now has a `pytest --build` that rebuilds the image for us, which was helpful when testing.

In case we decide to replace H2ORestart with something else (see #12), it will be possible to remove Java altogether, and that will remove an extra 60MiB (down to 333 MiB)