### PR TITLE
Fix some small bugs that affected our CI

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -263,9 +263,8 @@ jobs:
           file: Dockerfile
           context: ./src/
           platforms: ${{ matrix.platform.name }}
-          buildkit_image: ${{ needs.prepare.outputs.buildkit_image }}
           runtime: docker
-          source_date_epoch: ${{ needs.prepare.outputs.source_date_epoch }}
+          source_date_epoch: ${{ needs.merge.outputs.source_date_epoch }}
           build-args: DEBIAN_ARCHIVE_DATE=${{ needs.merge.outputs.debian_archive_date }}
 
   sign:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -114,7 +114,6 @@ jobs:
           buildkit_image: ${{ needs.prepare.outputs.buildkit_image }}
           source_date_epoch: ${{ needs.prepare.outputs.source_date_epoch }}
           push: true
-          provenance: false
           outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image_name }}",push-by-digest=true,push=true,name-canonical=true
           build-args: DEBIAN_ARCHIVE_DATE=${{ needs.prepare.outputs.debian_archive_date }}
           annotations: rocks.dangerzone.debian_archive_date=${{ needs.prepare.outputs.debian_archive_date }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -247,8 +247,10 @@ jobs:
         platform:
           - runs-on: "ubuntu-24.04"
             name: "linux/amd64"
+            arch: "amd64"
           - runs-on: "ubuntu-24.04-arm"
             name: "linux/arm64"
+            arch: "arm64"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -257,7 +259,7 @@ jobs:
       - name: Reproduce and verify image
         uses: freedomofpress/repro-build/verify@b4c783c4458bbd0ee430f516e0ed3a60108e61da # 1.0.0
         with:
-          target_image: ${{ needs.merge.outputs.image }}@${{ needs.merge.outputs[format('digest_{0}', matrix.platform.name)] }}
+          target_image: ${{ needs.merge.outputs.image }}@${{ needs.merge.outputs[format('digest_{0}', matrix.platform.arch)] }}
           file: Dockerfile
           context: ./src/
           platforms: ${{ matrix.platform.name }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 0
 
       - name: Reproduce and verify image
-        uses: freedomofpress/repro-build/verify@b4c783c4458bbd0ee430f516e0ed3a60108e61da # 1.0.0
+        uses: freedomofpress/repro-build/verify@e3539de5c53c198f897fe6053ec2662f8f0e9bf3 # 1.1.0
         with:
           target_image: ${{ needs.merge.outputs.image }}@${{ needs.merge.outputs[format('digest_{0}', matrix.platform.arch)] }}
           file: Dockerfile

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -265,6 +265,7 @@ jobs:
           runtime: docker
           source_date_epoch: ${{ needs.merge.outputs.source_date_epoch }}
           build-args: DEBIAN_ARCHIVE_DATE=${{ needs.merge.outputs.debian_archive_date }}
+          buildkit_image: moby/buildkit:latest
 
   sign:
     if: ${{ inputs.sign }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -266,6 +266,7 @@ jobs:
           source_date_epoch: ${{ needs.merge.outputs.source_date_epoch }}
           build-args: DEBIAN_ARCHIVE_DATE=${{ needs.merge.outputs.debian_archive_date }}
           buildkit_image: moby/buildkit:latest
+          annotations: rocks.dangerzone.debian_archive_date=${{ needs.merge.outputs.debian_archive_date }}
 
   sign:
     if: ${{ inputs.sign }}

--- a/.github/workflows/publish_dashboard.yml
+++ b/.github/workflows/publish_dashboard.yml
@@ -36,10 +36,15 @@ jobs:
       - name: Install grype
         run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
       - name: Build container image from main
         run: |
-          python3 build-image.py \
-            --debian-archive-date $(date "+%Y%m%d") \
+          uv run image build \
+            -d $(date "+%Y%m%d") \
             --runtime docker
           docker load -i container.tar
 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -212,3 +212,16 @@ ignore:
   #
   # [1]: https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0009
   - vulnerability: CVE-2026-5450
+
+  # CVE-2026-7210
+  # ==============
+  #
+  # Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-7210
+  #
+  # xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for
+  # Expat hash-flooding protection, allowing crafted XML to trigger hash
+  # flooding. Dangerzone is not affected because it does not parse untrusted XML
+  # documents using the Python XML modules during document conversion; document
+  # conversion is handled by LibreOffice. The Debian security team also classifies
+  # this as a minor issue (no-dsa).
+  - vulnerability: CVE-2026-7210


### PR DESCRIPTION
Make the following changes to make our CI green again:
* Refer to image digests with the proper name in `check-reproducibility` step.
* Use the new `image build` command when publishing the security dashboard.
* Ignore CVE-2026-7210