### PR TITLE
fix(ci): Use absolute paths in security dashboard

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
 
       - name: Verify that the Dockerfile matches the committed template and params
         run: |-

--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -820,8 +820,8 @@
             </div>
         </div>
         <div class="view-switch" role="navigation" aria-label="Report view">
-            <a href="index.html" data-view="latest">Latest</a>
-            <a href="nightly/" data-view="nightly">Nightly</a>
+            <a href="/index.html" data-view="latest">Latest</a>
+            <a href="/nightly/" data-view="nightly">Nightly</a>
         </div>
         <div class="severity-info">
             <div class="severity-box" id="critical">


### PR DESCRIPTION
Use absolute paths in the security dashboard, else navigation by clicking will be broken, because a path like `nightly/nightly` might be constructed.