### PR TITLE
CI: Add missing uv dependency for Dockerfile lint

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
 
       - name: Verify that the Dockerfile matches the committed template and params
         run: |-


### PR DESCRIPTION
The CI might fail if the Dockerfile changes, because of a missing `uv` dependency.