### PR TITLE
Improve the workflow for creating RPM packages for Qubes

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify that the Dockerfile matches the committed template and params
         run: |-
           cp Dockerfile Dockerfile.orig
-          make Dockerfile
+          make -B Dockerfile
           diff Dockerfile.orig Dockerfile
 
   prepare:

--- a/docs/qubes.md
+++ b/docs/qubes.md
@@ -2,10 +2,40 @@
 
 ## Build an RPM package
 
-You can build an RPM package for Qubes using the following commands:
+### From a Fedora environment
+
+Install some dependencies first:
+
+```
+sudo dnf install -y python3-uv-build python3-pymupdf python3-magic
+```
+
+Build the RPM package:
+
+```
+./qubes/build-rpm.sh
+```
+
+The RPM package will be stored under `./qubes/dist`.
+
+### From a container
+
+Install Podman (or Docker, and adjust accordingly):
+
+```
+sudo dnf install -y podman
+```
+
+Build the `dz-rpm-builder` image, that contains the tools to build the Qubes
+RPM:
 
 ```
 podman build -t dz-rpm-builder qubes/
+```
+
+Build the RPM package:
+
+```
 podman run --rm -v .:/root/dangerzone-image dz-rpm-builder
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.7,<0.11.0"]
+requires = ["uv_build"]
 build-backend = "uv_build"
 
 [project.scripts]

--- a/qubes/build-rpm.sh
+++ b/qubes/build-rpm.sh
@@ -3,12 +3,15 @@
 set -e
 set -x
 
-SCRIPT_DIR="$( dirname -- "$0" )"
-ROOT_DIR=${SCRIPT_DIR}/../
-RPMBUILD_DIR=${ROOT_DIR}/../rpmbuild/
+SCRIPT_DIR="$( realpath -- $( dirname -- "$0" ) )"
+ROOT_DIR="$( realpath -- ${SCRIPT_DIR}/../ )"
+RPMBUILD_DIR=~/rpmbuild/
 
 cd $ROOT_DIR
 rpmbuild -ba -v --build-in-place ${SCRIPT_DIR}/dangerzone-insecure-converter.spec
 
 echo "Copying RPMs under ./qubes/dist/"
-cp -v ${RPMBUILD_DIR}/RPMS/**/dangerzone-insecure-converter* ${RPMBUILD_DIR}SRPMS/dangerzone-insecure-converter* ${SCRIPT_DIR}/dist
+cp -v \
+    ${RPMBUILD_DIR}/RPMS/**/dangerzone-insecure-converter*.noarch.rpm \
+    ${RPMBUILD_DIR}/SRPMS/dangerzone-insecure-converter*.src.rpm \
+    ${SCRIPT_DIR}/dist

--- a/qubes/dangerzone-insecure-converter.spec
+++ b/qubes/dangerzone-insecure-converter.spec
@@ -50,6 +50,8 @@ Requires:       libreoffice
 
 install -pm 755 -d %{buildroot}/etc/qubes-rpc
 install -pm 755 qubes/qubes-rpc/* %{buildroot}/etc/qubes-rpc
+# No need to install the `image` script, since it's dev-facing.
+rm -f %{buildroot}%{_bindir}/image
 
 %check
 %pyproject_check_import


### PR DESCRIPTION
The current way we build RPM packages for Qubes has a couple of problems:

1. The `uv_build` restriction is too strict, and the latest `python3-uv-build` package from Fedora 43 cannot satisfy it.
2. The build script cannot be invoked from any location. This causes a problem if we follow the Qubes instructions in the `freedomofpress/dangerzone` repo, which invoke this script outside the `dangerzone-image/` dir.
3. We need to ignore the recently added `image` script.
4. Our docs are not explaining properly what are the two options our users have for building the RPM package for Qubes (in host vs. containerized).

This PR fixes the above problems. A similar PR will land on the Dangerzone repo, that works on top of this PR and builds RPM packages for Qubes more easily.